### PR TITLE
[opt](split) optimize the split manner of hive and hudi

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -337,10 +337,11 @@ public abstract class FileQueryScanNode extends FileScanNode {
                 locationType = getLocationType(fileSplit.getPath().toString());
             }
             totalFileSize = fileSplit.getLength() * inputSplitsNum;
+            long maxWaitTime = ConnectContext.get().getSessionVariable().getFetchSplitsMaxWaitTime();
             // Not accurate, only used to estimate concurrency.
             int numSplitsPerBE = numApproximateSplits() / backendPolicy.numBackends();
             for (Backend backend : backendPolicy.getBackends()) {
-                SplitSource splitSource = new SplitSource(backend, splitAssignment);
+                SplitSource splitSource = new SplitSource(backend, splitAssignment, maxWaitTime);
                 splitSources.add(splitSource);
                 Env.getCurrentEnv().getSplitSourceManager().registerSplitSource(splitSource);
                 TScanRangeLocations curLocations = newLocations();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/TablePartitionValues.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/TablePartitionValues.java
@@ -49,6 +49,21 @@ import java.util.stream.Collectors;
 
 @Data
 public class TablePartitionValues {
+    public enum PartitionOrdering {
+        NATURAL,
+        REVERSE,
+        SHUFFLE;
+
+        public static PartitionOrdering parse(String ordering) {
+            for (PartitionOrdering order : PartitionOrdering.values()) {
+                if (order.name().equalsIgnoreCase(ordering)) {
+                    return order;
+                }
+            }
+            return null;
+        }
+    }
+
     public static final String HIVE_DEFAULT_PARTITION = "__HIVE_DEFAULT_PARTITION__";
 
     private final ReadWriteLock readWriteLock;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -386,9 +386,9 @@ public class HudiScanNode extends HiveScanNode {
             return getIncrementalSplits();
         }
         if (!partitionInit) {
-            prunedPartitions = HiveMetaStoreClientHelper.ugiDoAs(
+            prunedPartitions = orderingPartitions(HiveMetaStoreClientHelper.ugiDoAs(
                     HiveMetaStoreClientHelper.getConfiguration(hmsTable),
-                    () -> getPrunedPartitions(hudiClient, snapshotTimestamp));
+                    () -> getPrunedPartitions(hudiClient, snapshotTimestamp)));
             partitionInit = true;
         }
         List<Split> splits = Collections.synchronizedList(new ArrayList<>());
@@ -448,9 +448,9 @@ public class HudiScanNode extends HiveScanNode {
         }
         if (!partitionInit) {
             // Non partition table will get one dummy partition
-            prunedPartitions = HiveMetaStoreClientHelper.ugiDoAs(
+            prunedPartitions = orderingPartitions(HiveMetaStoreClientHelper.ugiDoAs(
                     HiveMetaStoreClientHelper.getConfiguration(hmsTable),
-                    () -> getPrunedPartitions(hudiClient, snapshotTimestamp));
+                    () -> getPrunedPartitions(hudiClient, snapshotTimestamp)));
             partitionInit = true;
         }
         int numPartitions = ConnectContext.get().getSessionVariable().getNumPartitionsInBatchMode();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -417,6 +417,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String NUM_PARTITIONS_IN_BATCH_MODE = "num_partitions_in_batch_mode";
 
+    public static final String FETCH_SPLITS_MAX_WAIT_TIME = "fetch_splits_max_wait_time";
+
     /**
      * use insert stmt as the unified backend for all loads
      */
@@ -1460,6 +1462,13 @@ public class SessionVariable implements Serializable, Writable {
                     "If the number of partitions exceeds the threshold, scan ranges will be got through batch mode."},
             needForward = true)
     public int numPartitionsInBatchMode = 1024;
+
+    @VariableMgr.VarAttr(
+            name = FETCH_SPLITS_MAX_WAIT_TIME,
+            description = {"batch方式中BE获取splits的最大等待时间",
+                    "The max wait time of getting splits in batch mode."},
+            needForward = true)
+    public long fetchSplitsMaxWaitTime = 4000;
 
     @VariableMgr.VarAttr(
             name = ENABLE_PARQUET_LAZY_MAT,
@@ -2711,6 +2720,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setNumSplitsInBatchMode(int numPartitionsInBatchMode) {
         this.numPartitionsInBatchMode = numPartitionsInBatchMode;
+    }
+
+    public long getFetchSplitsMaxWaitTime() {
+        return fetchSplitsMaxWaitTime;
+    }
+
+    public void setFetchSplitsMaxWaitTime(long fetchSplitsMaxWaitTime) {
+        this.fetchSplitsMaxWaitTime = fetchSplitsMaxWaitTime;
     }
 
     public boolean isEnableParquetLazyMat() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -419,6 +419,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String FETCH_SPLITS_MAX_WAIT_TIME = "fetch_splits_max_wait_time";
 
+    public static final String PARTITION_ORDERING = "partition_ordering";
+
     /**
      * use insert stmt as the unified backend for all loads
      */
@@ -1469,6 +1471,13 @@ public class SessionVariable implements Serializable, Writable {
                     "The max wait time of getting splits in batch mode."},
             needForward = true)
     public long fetchSplitsMaxWaitTime = 4000;
+
+    @VariableMgr.VarAttr(
+            name = PARTITION_ORDERING,
+            description = {"list partition的排序方式",
+                    "Ordering style of list partition."},
+            needForward = true)
+    public String partitionOrdering = "natural";
 
     @VariableMgr.VarAttr(
             name = ENABLE_PARQUET_LAZY_MAT,
@@ -2728,6 +2737,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setFetchSplitsMaxWaitTime(long fetchSplitsMaxWaitTime) {
         this.fetchSplitsMaxWaitTime = fetchSplitsMaxWaitTime;
+    }
+
+    public String getPartitionOrdering() {
+        return partitionOrdering;
+    }
+
+    public void setPartitionOrdering(String partitionOrdering) {
+        this.partitionOrdering = partitionOrdering;
     }
 
     public boolean isEnableParquetLazyMat() {


### PR DESCRIPTION
## Proposed changes

`fetch_splits_max_wait_time ` to set the max wait time of getting splits;

`partition_ordering` to set the ordering style of listing partitions: natural(in default), reverse, shuffle


